### PR TITLE
Update KeePassX.download.recipe

### DIFF
--- a/KeePassX/KeePassX.download.recipe
+++ b/KeePassX/KeePassX.download.recipe
@@ -27,7 +27,7 @@
 				<key>Comment</key>
 				<string>The URL key calls the page where the download is found.</string>
 				<key>re_pattern</key>
-				<string>(/releases/KeePassX-[0-9].[0-9].[0-9].dmg)</string>
+				<string>(/releases/\d?[.]?\(?\d\)?[.]?\d[-.\s]?/KeePassX-\d?[.]?\(?\d\)?[.]?\d[-.\s]?.dmg)</string>
 				<key>Comment</key>
 				<string>The re_pattern calls the variables the file might be called.</string>
 				<key>result_output_var_name</key>


### PR DESCRIPTION
I had to modify your regular expression in order to actually retrieve the latest (stable) version.

```
\d?[.]?\(?\d\)?[.]?\d[-.\s]?
```

matches

```
2.0.1
2.0.2
2.0
```

I'm sure there's a better or faster way to look for the version number(s).

HTH
