### PR TITLE
Fix issues with Onyx10.11.munki.recipe

### DIFF
--- a/Onyx10.11/Onyx10.11.munki.recipe
+++ b/Onyx10.11/Onyx10.11.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Onyx.app for MacOS Sierra and imports it into a Munki repo.</string>
+	<string>Downloads the latest Onyx.app for MacOS El Capitan and imports it into a Munki repo.</string>
 	<key>Identifier</key>
 	<string>com.github.tallfunnyjew.munki.Onyx1011</string>
 	<key>Input</key>

--- a/Onyx10.11/Onyx10.11.munki.recipe
+++ b/Onyx10.11/Onyx10.11.munki.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the latest Onyx.app for MacOS Sierra and imports it into a Munki repo.</string>
 	<key>Identifier</key>
-	<string>com.github.tallfunnyjew.munki.Onyx1012</string>
+	<string>com.github.tallfunnyjew.munki.Onyx1011</string>
 	<key>Input</key>
 	<dict>
 		<key>APP_DESTINATION</key>
@@ -13,7 +13,7 @@
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>global/apps/Onyx</string>
 		<key>NAME</key>
-		<string>Onyx12</string>
+		<string>Onyx11</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -25,11 +25,11 @@
 			<key>description</key>
 			<string>OnyX is a multifunctional utility for OS X. It allows you to verify the startup disk and the structure of its System files, to run miscellaneous tasks of system maintenance, to configure the hidden parameters of the Finder, Dock, Spotlight, and of some of Apple's own applications, to delete caches, to remove a certain number of files and folders that may become cumbersome, and more.
 &amp;lt;br&amp;gt;&amp;lt;br&amp;gt;
-&amp;lt;img src="http://www.titanium.free.fr/images/icons/onyx1012.png"&amp;gt;</string>
+&amp;lt;img src="http://www.titanium.free.fr/images/icons/onyx1011.png"&amp;gt;</string>
 			<key>developer</key>
 			<string>Titanium</string>
 			<key>display_name</key>
-			<string>Onyx for OSX 10.12</string>
+			<string>Onyx for OSX 10.11</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -39,7 +39,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.tallfunnyjew.download.Onyx1012</string>
+	<string>com.github.tallfunnyjew.download.Onyx1011</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Fixed an issue with Onyx10.11.munki.recipe wherein it would instead download and import Onyx10.12. This was resolved primarily by amending the Identifier and ParentRecipe strings. Also amended the Description and Name to reflect these changes.

Changes have been tested and appear to work (i.e., the recipe now correctly downloads Onyx10.11 and imports into Munki).