### PR TITLE
Use %pkg_path% instead of %pathname% for MunkiImporter

### DIFF
--- a/Garmin/Garmin.munki.recipe
+++ b/Garmin/Garmin.munki.recipe
@@ -46,7 +46,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pathname%</string>
+                <string>%pkg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
By using %pkg_path% as value for the pkg_path parameter for MunkiImporter, munki imports the package created by Garmin.pkg.recipe; if you use %pathname% I think autopkg tries to import the downloaded dmg file, and this creates problems with updates within the same major version of Garmin Express (at least, when there was clearly a new version, our autopkg claimed it was already in the munki repo).

It might be possible to skip the pkg_path parameter to MunkiImporter entirely now (because pkg_path is %pkg_path% by default), but I did not check that.