### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/AVG/AVGAntiVirus.install.recipe
+++ b/AVG/AVGAntiVirus.install.recipe
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>/Applications/AVGAntivirus.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>

--- a/Citrix/CitrixReceiver.install.recipe
+++ b/Citrix/CitrixReceiver.install.recipe
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>/Applications/Citrix Receiver.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>

--- a/Moneydance/Moneydance.download.recipe
+++ b/Moneydance/Moneydance.download.recipe
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Moneydance.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>
@@ -54,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Moneydance.app</string>
                 <key>requirement</key>
                 <string>identifier "com.infinitekind.MoneydanceOSX" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "978HG93KDK"</string>
             </dict>
@@ -65,7 +65,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Moneydance.app</string>
                 <key>target</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%.app</string>
             </dict>

--- a/Skitch/Skitch.download.recipe
+++ b/Skitch/Skitch.download.recipe
@@ -43,7 +43,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Skitch.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.skitch.skitch" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = J8RPQ294UB)</string>
             </dict>

--- a/Telegram/Telegram.download.recipe
+++ b/Telegram/Telegram.download.recipe
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Telegram.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "ru.keepcoder.Telegram" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6N38VWS5BX")</string>
             </dict>

--- a/iDrive/iDrive.install.recipe
+++ b/iDrive/iDrive.install.recipe
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>/Applications/iDrive.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleVersion</string>
             </dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.