### PR TITLE
Remove PathDeleter processor

### DIFF
--- a/Telegram/Telegram.pkg.recipe
+++ b/Telegram/Telegram.pkg.recipe
@@ -21,17 +21,6 @@
             <key>Processor</key>
             <string>AppPkgCreator</string>
         </dict>
-        <dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/payload</string>
-				</array>
-			</dict>
-        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This processors gives me this error:
`Processor: PathDeleter: Error: Could not remove /Users/admin/Library/AutoPkg/Cache/local.pkg.Telegram/payload - it does not exist!`