### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/OpenDNS/OpenDNS.pkg.recipe
+++ b/OpenDNS/OpenDNS.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.opendns.OpenDNS_Updater</string>
 		<key>NAME</key>
 		<string>OpenDNS Updater</string>
 	</dict>
@@ -22,8 +20,6 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
 			<key>Arguments</key>
 			<dict>
 				<key>archive_path</key>
@@ -33,15 +29,17 @@
 				<key>purge_destination</key>
 				<true/>
 			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
 		</dict>
 		<dict>
-			<key>Processor</key>
-			<string>AppPkgCreator</string>
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/OpenDNS Updater.app</string>
 			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ❌ OpenDNS/OpenDNS.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/tallfunnyjew-recipes/OpenDNS/OpenDNS.pkg.recipe
Processing repos/tallfunnyjew-recipes/OpenDNS/OpenDNS.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://opendnsupdate.appspot.com/macupdatecheck/ipupdater/AppCast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3.0
SparkleUpdateInfoProvider: Found URL https://opendns.s3.amazonaws.com/software/mac/dynamicupdate/3.0/OpenDNS-Updater-Mac-3.0.zip
{'Output': {'url': 'https://opendns.s3.amazonaws.com/software/mac/dynamicupdate/3.0/OpenDNS-Updater-Mac-3.0.zip',
            'version': '3.0'}}
URLDownloader
{'Input': {'filename': 'OpenDNS Updater-3.0.zip',
           'url': 'https://opendns.s3.amazonaws.com/software/mac/dynamicupdate/3.0/OpenDNS-Updater-Mac-3.0.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/downloads/OpenDNS Updater-3.0.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/downloads/OpenDNS '
                        'Updater-3.0.zip'}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/downloads/OpenDNS '
                           'Updater-3.0.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/OpenDNS '
                               'Updater',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename OpenDNS Updater-3.0.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/downloads/OpenDNS Updater-3.0.zip to ~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/OpenDNS Updater
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/OpenDNS '
                       'Updater/OpenDNS Updater.app',
           'version': '3.0'}}
AppPkgCreator: BundleID: com.opendns.OpenDNS_Updater
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/OpenDNS Updater/OpenDNS Updater.app to ~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/payload/Applications/OpenDNS Updater.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater/receipts/OpenDNS.pkg-receipt-20210213-225136.plist

The following recipes failed:
    repos/tallfunnyjew-recipes/OpenDNS/OpenDNS.pkg.recipe
        Error in com.github.autopkg.tallfunnyjew-recipes.pkg.OpenDNSUpdater: Processor: AppPkgCreator: Error: Invalid package id

Nothing downloaded, packaged or imported.
```

