### PR TITLE
Remove non-existent path from PathDeleter in VLC-Arm-asap pkg recipe

### DIFF
--- a/VLC-Arm-asap/VLC-Arm-asap.pkg.recipe
+++ b/VLC-Arm-asap/VLC-Arm-asap.pkg.recipe
@@ -28,7 +28,6 @@
 			<dict>
 				<key>path_list</key>
 				<array>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 					<string>%RECIPE_CACHE_DIR%/payload</string>
 				</array>
 			</dict>


### PR DESCRIPTION
Recipes that have this as a parent continually fail because of this