### PR TITLE
Remove non-existent path from PathDeleter in VLC-Intel-asap pkg recipe

### DIFF
--- a/VLC-Intel-asap/VLC-Intel-asap.pkg.recipe
+++ b/VLC-Intel-asap/VLC-Intel-asap.pkg.recipe
@@ -28,7 +28,6 @@
 			<dict>
 				<key>path_list</key>
 				<array>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 					<string>%RECIPE_CACHE_DIR%/payload</string>
 				</array>
 			</dict>


### PR DESCRIPTION
Same as #25 