### PR TITLE
Update Telegram.download.recipe

### DIFF
--- a/Telegram/Telegram.download.recipe
+++ b/Telegram/Telegram.download.recipe
@@ -3,15 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-	<string>Downloads the latest version  of Telegram version for macOS.</string>
-	<key>Identifier</key>
-	<string>com.github.tallfunnyjew.download.Telegram</string>
+    <string>Downloads the latest version of Telegram version for macOS.</string>
+    <key>Identifier</key>
+    <string>com.github.tallfunnyjew.download.Telegram</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Telegram</string>
-		<key>DOWNLOAD_URL</key>
-        <string>https://telegram.org/dl/macos</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.1</string>
@@ -22,10 +20,10 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://telegram.org/dl/macos</string>
             </dict>
         </dict>
         <dict>
@@ -37,6 +35,8 @@
                 <string>%pathname%/%NAME%.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "ru.keepcoder.Telegram" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6N38VWS5BX")</string>
+                <key>strict_verification</key>
+                <true/>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
- Fix spacing
- Remove download url from input variables. This isn't changing so no reason to not hardcode in the URLDownloader processor
- Add strict_verification
- alphabetize arguments

Recipe run:
```
autopkg run -vv ~/Documents/git/tallfunnyjew-recipes/Telegram/Telegram.download.recipe                         
Processing /Users/autopkgadmin/Documents/git/tallfunnyjew-recipes/Telegram/Telegram.download.recipe...
WARNING: /Users/autopkgadmin/Documents/git/tallfunnyjew-recipes/Telegram/Telegram.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Telegram.dmg', 'url': 'https://telegram.org/dl/macos'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 01 Feb 2022 06:39:05 GMT
URLDownloader: Storing new ETag header: "61f8d589-4c528cf"
URLDownloader: Downloaded /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.tallfunnyjew.download.Telegram/downloads/Telegram.dmg
{'Output': {'download_changed': True,
            'etag': '"61f8d589-4c528cf"',
            'last_modified': 'Tue, 01 Feb 2022 06:39:05 GMT',
            'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.tallfunnyjew.download.Telegram/downloads/Telegram.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.tallfunnyjew.download.Telegram/downloads/Telegram.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.tallfunnyjew.download.Telegram/downloads/Telegram.dmg/Telegram.app',
           'requirement': 'anchor apple generic and identifier '
                          '"ru.keepcoder.Telegram" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "6N38VWS5BX")',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.tallfunnyjew.download.Telegram/downloads/Telegram.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.Remyoe/Telegram.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Remyoe/Telegram.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Remyoe/Telegram.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.tallfunnyjew.download.Telegram/receipts/Telegram.download-receipt-20220204-174559.plist

The following new items were downloaded:
    Download Path                                                                                      
    -------------                                                                                      
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.tallfunnyjew.download.Telegram/downloads/Telegram.dmg
```