### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/AVG/AVGAntiVirus.download.recipe
+++ b/AVG/AVGAntiVirus.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>AVGAntiVirus</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.avg.com/ww-en/download-file-mac-av</string>
+        <string>https://www.avg.com/ww-en/download-file-mac-av</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.1</string>

--- a/ComicLife/ComicLife3.download.recipe
+++ b/ComicLife/ComicLife3.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>ComicLife3</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://downloads.plasq.com/comiclife3.zip</string>
+        <string>https://downloads.plasq.com/comiclife3.zip</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.1</string>

--- a/EvolisPrimacy/Primacy.download.recipe
+++ b/EvolisPrimacy/Primacy.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://us.evolis.com/drivers-support/drivers-primacy-card-printer</string>
+                <string>https://us.evolis.com/drivers-support/drivers-primacy-card-printer</string>
                 <key>re_pattern</key>
                 <string>(https:\/\/us\.evolis\.com\/sites\/default\/files\/atoms\/files\/evolisprinterdriver-[\d.]*.pkg_.zip)</string>
                 <key>result_output_var_name</key>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!