### PR TITLE
Deprecate broken MusicBrainz Picard recipes

### DIFF
--- a/MusicBrainzPicard/MusicBrainzPicard.download.recipe
+++ b/MusicBrainzPicard/MusicBrainzPicard.download.recipe
@@ -15,6 +15,10 @@
     <string>1.0.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
 		<dict>
 		<key>Processor</key>
 		<string>URLTextSearcher</string>


### PR DESCRIPTION
New recipes exist in the dataJAR-recipes repo: https://github.com/autopkg/dataJAR-recipes/tree/master/MusicBrainz%20Picard