### PR TITLE
Deprecate broken OpenDNS recipes

### DIFF
--- a/OpenDNS/OpenDNS.download.recipe
+++ b/OpenDNS/OpenDNS.download.recipe
@@ -21,6 +21,10 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This software has been replaced with Cisco Secure Client, and OpenDNS Umbrella is no longer downloadable.