### PR TITLE
Deprecate Citrix Receiver recipes

### DIFF
--- a/Citrix/CitrixReceiver.download.recipe
+++ b/Citrix/CitrixReceiver.download.recipe
@@ -6,35 +6,44 @@
     <string>Downloads the latest version of Citrix Receiver.</string>
     <key>Identifier</key>
     <string>com.github.tallfunnyjew.download.CitrixReceiver</string>
-		<key>Input</key>
-		<dict>
-			<key>NAME</key>
-			<string>CitrixReceiver</string>
-		</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.1</string>
-	<key>Process</key>
-	<array>
-		<dict>
-		<key>Processor</key>
-		<string>URLTextSearcher</string>
-		<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://www.citrix.com/downloads/citrix-receiver/mac/receiver-for-mac-latest.html</string>
-				<key>re_pattern</key>
-				<string>(downloads\.citrix\.com\/[\d]*\/CitrixReceiver\.dmg\?__gda__\=[\w]*)</string>
-			</dict>
-		</dict>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>CitrixReceiver</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Citrix Receiver was replaced by Citrix Workspace in August 2018 (details: https://www.citrix.com/downloads/citrix-receiver/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>(downloads\.citrix\.com\/[\d]*\/CitrixReceiver\.dmg\?__gda__\=[\w]*)</string>
+                <key>url</key>
+                <string>https://www.citrix.com/downloads/citrix-receiver/mac/receiver-for-mac-latest.html</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>https://%match%</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://%match%</string>
             </dict>
         </dict>
         <dict>
@@ -42,14 +51,14 @@
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
-                <key>input_path</key>
-                <string>%pathname%/Install Citrix Receiver.pkg</string>
                 <key>expected_authority_names</key>
                 <array>
                     <string>Developer ID Installer: Citrix Systems, Inc. (KBVSJ83SS9)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>
+                <key>input_path</key>
+                <string>%pathname%/Install Citrix Receiver.pkg</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Citrix Receiver was replaced by Citrix Workspace in August 2018 (details: https://www.citrix.com/downloads/citrix-receiver/). This PR deprecates the Citrix Receiver recipes.