### PR TITLE
Deprecate Handbrake recipes

### DIFF
--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -12,22 +12,31 @@
         <string>Handbrake</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
-		<key>Processor</key>
-		<string>URLTextSearcher</string>
-		<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://handbrake.fr/downloads.php</string>
-				<key>re_pattern</key>
-				<string>&gt;Current Version: ([\d\.]+)&lt;</string>
-				<key>result_output_var_name</key>
-				<string>version</string>
-			</dict>
-		</dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to one of the Handbrake recipes in the autopkg/keeleysam-recipes or autopkg/recipes repos. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+        <key>Processor</key>
+        <string>URLTextSearcher</string>
+        <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://handbrake.fr/downloads.php</string>
+                <key>re_pattern</key>
+                <string>&gt;Current Version: ([\d\.]+)&lt;</string>
+                <key>result_output_var_name</key>
+                <string>version</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Handbrake/HandbrakeCLI.download.recipe
+++ b/Handbrake/HandbrakeCLI.download.recipe
@@ -12,23 +12,31 @@
         <string>HandbrakeCLI</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
-		<key>Processor</key>
-		<string>URLTextSearcher</string>
-		<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://handbrake.fr/downloads2.php</string>
-				<key>re_pattern</key>
-				<string>&gt;Current Version: ([\d\.]+)&lt;</string>
-				<key>result_output_var_name</key>
-				<string>version</string>
-			</dict>
-		</dict>
- 
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the HandBrakeCLI recipes in the orbsmiv-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>&gt;Current Version: ([\d\.]+)&lt;</string>
+                <key>result_output_var_name</key>
+                <string>version</string>
+                <key>url</key>
+                <string>https://handbrake.fr/downloads2.php</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates the non-functional Handbrake recipes in this repo, and points users to working equivalents in the keeleysam-recipes or recipes repos.

Also marked deprecated are the non-functional HandbrakeCLI recipes, and users are directed to working equivalents in the orbsmiv-recipes repo.

