### PR TITLE
Deprecate end of life Evolis driver download recipes

### DIFF
--- a/EvolisDualys/Dualys2.download.recipe
+++ b/EvolisDualys/Dualys2.download.recipe
@@ -14,9 +14,18 @@
 		<string>https://us.evolis.com/sites/default/files/drivers/11267_187671_EvolisCardPinter-3.02-Universal.zip</string>
 	</dict>
     <key>MinimumVersion</key>
-    <string>1.0.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Evolis Dualys 2 is "end of life" (details: https://evolisprinter.com/dualys-support/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/EvolisDualys/Dualys3.download.recipe
+++ b/EvolisDualys/Dualys3.download.recipe
@@ -12,11 +12,20 @@
 		<string>EvolisDualys3</string>
 	</dict>
     <key>MinimumVersion</key>
-    <string>1.0.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
-		<dict>
-			<key>Processor</key>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Evolis Dualys 2 is "end of life" (details: https://evolisprinter.com/dualys-support/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>

--- a/EvolisPrimacy/Primacy.download.recipe
+++ b/EvolisPrimacy/Primacy.download.recipe
@@ -12,11 +12,20 @@
         <string>EvolisPrimacy</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
-			<key>Processor</key>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Evolis Primacy is "end of life" (details: https://evolisprinter.com/primacy-support/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the end-of-life Evolis driver download recipes.

Details:
- https://evolisprinter.com/dualys-support/
- https://evolisprinter.com/primacy-support/
