### PR TITLE
Deprecate KeePassX recipes

### DIFF
--- a/KeePassX/KeePassX.download.recipe
+++ b/KeePassX/KeePassX.download.recipe
@@ -14,9 +14,18 @@
 		<string>KeePassX</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the KeePassX recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 		<key>Processor</key>
 		<string>URLTextSearcher</string>


### PR DESCRIPTION
In order to simplify AutoPkg recipe search results, this PR deprecates the KeePassX recipes, which are redundant with the ones in my homebysix-recipes repo.
