### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/iDrive/iDrive.download.recipe
+++ b/iDrive/iDrive.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>iDrive</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.idrive.com/downloads/IDrive.dmg</string>
+        <string>https://www.idrive.com/downloads/IDrive.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.1</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._